### PR TITLE
Handle Ory Gone responses on login screen

### DIFF
--- a/src/main/kotlin/com/faforever/userservice/domain/User.kt
+++ b/src/main/kotlin/com/faforever/userservice/domain/User.kt
@@ -21,7 +21,7 @@ data class User(
     val username: String,
     val password: String,
     val email: String,
-    val ip: String?,
+    val ip: String?
 ) {
 
     override fun toString(): String =
@@ -35,13 +35,12 @@ data class AccountLink(
     val id: String,
     @field:MappedProperty("user_id")
     val userId: Long?,
-    val ownership: Boolean,
+    val ownership: Boolean
 ) {
 
     override fun toString(): String =
         // Do NOT expose personal information here!!
         "AccountLink(id=$id)"
-
 }
 
 @MappedEntity("group_permission")

--- a/src/main/kotlin/com/faforever/userservice/domain/UserService.kt
+++ b/src/main/kotlin/com/faforever/userservice/domain/UserService.kt
@@ -71,6 +71,20 @@ class UserService(
          * The user role is used to distinguish users from technical accounts.
          */
         private const val ROLE_USER = "USER"
+        fun <T : Any> handleOryGoneRedirect(
+            exception: HttpClientResponseException,
+            redirectMapper: (String) -> T
+        ): Mono<T> =
+            if (exception.status == HttpStatus.GONE) {
+                val mappedResponse = exception.response.getBody(RequestWasHandledResponse::class.java)
+                    .map { redirectMapper(it.redirectTo) }
+                    .orElseThrow()
+
+                Mono.just(mappedResponse)
+            } else {
+                // pass through unknown error
+                Mono.error(exception)
+            }
     }
 
     fun findUserBySubject(subject: String) =
@@ -91,7 +105,7 @@ class UserService(
             ) {
                 val lastAttempt = it.lastAttemptAt!!
                 if (LocalDateTime.now().minusMinutes(securityProperties.failedLoginThrottlingMinutes)
-                        .isBefore(lastAttempt)
+                    .isBefore(lastAttempt)
                 ) {
                     LOG.debug("IP '$ip' is trying again to early -> throttle it")
                     true
@@ -156,7 +170,7 @@ class UserService(
                     }
                     .switchIfEmpty {
                         if (loginRequest.requestedScope.contains(OAuthScope.LOBBY)) {
-                            accountLinkRepository.existsByUserIdAndOwnership(user.id, true).flatMap {exists ->
+                            accountLinkRepository.existsByUserIdAndOwnership(user.id, true).flatMap { exists ->
                                 if (exists) {
                                     LOG.debug("User '$usernameOrEmail' logged in successfully")
 
@@ -259,19 +273,4 @@ class UserService(
                     redirectTo
                 }
             }
-
-    private fun <T : Any> handleOryGoneRedirect(
-        exception: HttpClientResponseException,
-        redirectMapper: (String) -> T
-    ): Mono<T> =
-        if (exception.status == HttpStatus.GONE) {
-            val mappedResponse = exception.response.getBody(RequestWasHandledResponse::class.java)
-                .map { redirectMapper(it.redirectTo) }
-                .orElseThrow()
-
-            Mono.just(mappedResponse)
-        } else {
-            // pass through unknown error
-            Mono.error(exception)
-        }
 }


### PR DESCRIPTION
Solves the errors from the log such as:

``` 
c.f.userservice.web.OAuthController- Getting consent request from Hydra failed for consent challenge [redacted]
faf-user-service         | io.micronaut.http.client.exceptions.HttpClientResponseException: Gone
```